### PR TITLE
In the last set of commits you pulled in I changed the database schema - for existing users - this would break  delegation database operations -- until the user reloaded the database.

### DIFF
--- a/blockfinder
+++ b/blockfinder
@@ -703,7 +703,11 @@ def main():
 
     for request in requests:
         try:
-            print " \n".join(block_f.use_sql_database(request, country))
+            try:
+                print " \n".join(block_f.use_sql_database(request, country))
+            except sqlite3.Error, e:
+                print repr(e)
+                print "Please try reloading the database. (run ./blockfinder -i)."
         except Exception, e:
             print repr(e)
     try:


### PR DESCRIPTION
In the last set of commits you pulled in I changed the database schema - for existing users(with a database) who upgrade this breaks  delegation database operations -- until the user reloaded the database. This commit adds a generic database error "hint" which we should accompany with a version number in the database -- to spot / do $x operation when the database version number does not match a user's blockfinder.py schema database version. 

We intend to put a version number in the database to detect database schema changes. However, for now if a sqlite3 error occurs suggest to the user that they reload the delegation database.

Signed-off-by: dave bl db@d1b.org
