### PR TITLE
Fix unhandled URLError, and fix a SyntaxError for an old Python2.x print statement.

### DIFF
--- a/blockfinder
+++ b/blockfinder
@@ -272,7 +272,7 @@ class DownloaderParser:
             local cache directory under the file name given in the URL. """
         if not os.path.exists(self.cache_dir):
             if self.verbose:
-                print "Initializing the cache directory..."
+                print("Initializing the cache directory...")
             os.mkdir(self.cache_dir)
         filename = url.split('/')[-1]
         req = urllib2.Request(url)


### PR DESCRIPTION
The original URLError would result in:

```
∃!isisⒶwintermute:~(master *) ∴ blockfinder -m && blockfinder -i
Downloading Maxmind GeoIP files...
Fetching 1203 kilobytes
[=================================================================================================================================================>] 376.32 K/s
Fetching 648 kilobytes
[=================================================================================================================================================>] 371.11 K/s
Importing Maxmind GeoIP files...
Downloading RIR files...
Fetching 3207 kilobytes
[=================================================================================================================================================>] 309.19 K/s
Fetching 0 kilobytes
[===================================================================================================================================================>] 0.00 K/s
Fetching 3897 kilobytes
[=================================================================================================================================================>] 320.68 K/s
Traceback (most recent call last):
  File "/usr/local/bin/blockfinder", line 885, in <module>
    main()
  File "/usr/local/bin/blockfinder", line 868, in main
    downloader_parser.download_rir_files()
  File "/usr/local/bin/blockfinder", line 258, in download_rir_files
    self._download_to_cache_dir(rir_md5_url)
  File "/usr/local/bin/blockfinder", line 283, in _download_to_cache_dir
    fetcher = urllib2.urlopen(req)
  File "/usr/lib/python2.7/urllib2.py", line 127, in urlopen
    return _opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 401, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 419, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 379, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1398, in ftp_open
    fp, retrlen = fw.retrfile(file, type)
  File "/usr/lib/python2.7/urllib.py", line 890, in retrfile
    conn, retrlen = self.ftp.ntransfercmd(cmd)
  File "/usr/lib/python2.7/ftplib.py", line 327, in ntransfercmd
    conn = socket.create_connection((host, port), self.timeout)
  File "/usr/lib/python2.7/socket.py", line 571, in create_connection
    raise err
urllib2.URLError: <urlopen error ftp error: [Errno 113] No route to host>
```

and my commit message for the patch shows what it looks like now:

```
* commit fbfa12690fdec98de8bc7080677a9dc84138a989
| gpg: Signature made Sat 08 Jun 2013 07:44:13 UTC
gpg:                using RSA key A3ADB67A2CDB8B35
gpg: Good signature from "Isis! <isis@patternsinthevoid.net>" [ultimate]
gpg:                 aka "Isis <isis@leap.se>" [ultimate]
gpg:                 aka "Isis <isis@torproject.org>" [ultimate]
gpg:                 aka "Isis! <isis@riseup.net>" [ultimate]
gpg: Signature notation: isis@patternsinthevoid.net=0A6A58A14B5946ABDE18E207A3ADB67A2CDB8B35
gpg: Signature expires Sun 08 Jun 2014 07:44:13 UTC
Author:     Isis Lovecruft <isis@torproject.org>
| AuthorDate: 44 minutes ago
| Commit:     Isis Lovecruft <isis@torproject.org>
| CommitDate: 8 minutes ago
| 
|     Catch "URLError: No route to host" while fetching and move to next url.
|     
|      * Before, if blockfinder was unable to resolve a hostname, it would barf up
|        the unhandled error in the terminal and exit. Instead, we should at least
|        catch the error, display a message to the user that there was a problem
|        caching whichever URL failed, and move on to the next URL. We might want to
|        retry the url instead, but my tests of this patch on my local network
|        (where DNS is highly tampered with and censored) show the following
|        results (instead of just crashing):
|     
|     ∃!isisⒶwintermute:blockfinder(develop *+=) ∴ blockfinder -i
|     Downloading RIR files...
|     Fetching 3207 kilobytes
|     [=============================================================>] 365.58 K/s
|     Fetching 0 kilobytes
|     [=============================================================>] 0.00 K/s
|     An error occurrred while attempting to cache file from:
|             ftp://ftp.ripe.net/ripe/stats/delegated-ripencc-latest
|             <urlopen error ftp error: [Errno 113] No route to host>
|     An error occurrred while attempting to cache file from:
|             ftp://ftp.ripe.net/ripe/stats/delegated-ripencc-latest.md5
|             <urlopen error ftp error: [Errno 113] No route to host>
|     Fetching 171 kilobytes
|     [=============================================================>] 67.89 K/s
|     [...]
|     Verifying RIR files...
|     Importing RIR files...
|     ∃!isisⒶwintermute:blockfinder(develop *+=) ∴
| 
|  blockfinder |    7 ++++++-
|  1 file changed, 6 insertions(+), 1 deletion(-)
```

❤Ⓐ
