### PR TITLE
Changed behavior to correctly process new formats from ARIN:

### DIFF
--- a/blockfinder
+++ b/blockfinder
@@ -276,7 +276,8 @@ class DownloaderParser:
                 print "Initializing the cache directory..."
             os.mkdir(self.cache_dir)
         filename = url.split('/')[-1]
-        print(url)
+        if self.verbose:
+            print(url)
         req = urllib2.Request(url)
         if self.user_agent:
             req.add_header('User-Agent', self.user_agent)
@@ -360,7 +361,8 @@ class DownloaderParser:
             if "=" in expected_checksum:
                 expected_checksum = expected_checksum.split("=")[-1].strip()
             elif expected_checksum == "":
-                print("No checksum... skipping verification...")
+                if self.verbose:
+                    print("No checksum... skipping verification...")
                 continue
             else:
                 regex = re.compile("[a-f0-9]{32}")


### PR DESCRIPTION
1) Change of name:
ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest
instead of
ftp://ftp.arin.net/pub/stats/arin/delegated-arin-latest

2) Change of MD5 checksum file format:
ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest.md5
contains:
11acb87299e13be8911a9ce45d49612e  delegated-arin-extended-20130827
instead of
ftp://ftp.arin.net/pub/stats/arin/delegated-arin-latest.md5
which contained:
MD5 (delegated-arin-latest) = 9e056d06a46740cb8cfed99702149c44

changed the code to look for 32 hex string if it previous parsing fails.

3) Change of file format from 2 to 2.3
ftp://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest
contains:
2.3|arin|1377579757580|105164|19700101|20130827|-0400
instead of:
2|arin|20130812|72395|00000000|20130811|-0400

so isdigit() failed on "2.3" string.

Now works.

Best,
Philippe.
## phil@p1sec.com

http://www.p1sec.com
