### PR TITLE
Correct exit code if ``failures % 256 == 0`` due to UNIX semantics

### DIFF
--- a/blockfindertest.py
+++ b/blockfindertest.py
@@ -145,4 +145,4 @@ if __name__ == '__main__':
         results = test_runner.run(test_suite)
         failures += len(results.errors)
         failures += len(results.failures)
-    sys.exit(failures)
+    sys.exit(bool(failures))


### PR DESCRIPTION
Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>