### PR TITLE
Discard duplicate per-country IP blocks

### DIFF
--- a/blockfinder
+++ b/blockfinder
@@ -967,17 +967,24 @@ class Lookup(object):
             print("AS%s not found!" % asn)
 
     def fetch_rir_blocks_by_country(self, request, country):
+        if request == "asn":
+            return [str(start_num) for (start_num, end_num) in
+                    self.database_cache.fetch_assignments(request, country)]
+        if request != "ipv4" and request != "ipv6":
+            return []
+        seen = set()
         result = []
         for (start_num, end_num) in \
                 self.database_cache.fetch_assignments(request, country):
-            if request == "ipv4" or request == "ipv6":
-                start_ipaddr = ipaddr.ip_address(start_num)
-                end_ipaddr = ipaddr.ip_address(end_num)
-                result += [str(x) for x in
-                           ipaddr.summarize_address_range(
-                    start_ipaddr, end_ipaddr)]
-            else:
-                result.append(str(start_num))
+            start_ipaddr = ipaddr.ip_address(start_num)
+            end_ipaddr = ipaddr.ip_address(end_num)
+            for block in (str(x) for x in
+                          ipaddr.summarize_address_range(start_ipaddr,
+                                                         end_ipaddr)):
+                if block in seen:
+                    continue
+                seen.add(block)
+                result.append(block)
         return result
 
     def lookup_countries_in_different_source(self, first_country_code):


### PR DESCRIPTION
Fixes #90 and supersedes PR #91.

This handles some corner-cases which would not be caught by the method used in the previous PR for this issue (#91) or by fetching the assignments from the database using a `SELECT DISTINCT`.
These corner-cases are due to an assignment being stored multiple times in the database, but with differing starting addresses. For example, 1.0.0.0/16 might be stored as two records:-

    start_hex    | next_start_hex | source_type
    -------------+----------------+-------------
    001000000    | 001010000      | rir
    -------------+----------------+-------------
    001000001    | 001010000      | maxmind

Therefore the duplicate blocks should be detected after such records are converted into a standard representation of an assignment by the `ipaddr.summarize_address_range` method.